### PR TITLE
Corrected buffer overflow error

### DIFF
--- a/TinyWireM.cpp
+++ b/TinyWireM.cpp
@@ -50,7 +50,7 @@ void USI_TWI::beginTransmission(uint8_t slaveAddr){ // setup address & write bit
 }
 
 size_t USI_TWI::write(uint8_t data){ // buffers up data to send
-  if (USI_BufIdx >= USI_BUF_SIZE) return 0;       // dont blow out the buffer
+  if (USI_BufIdx >= USI_BUF_SIZE-1) return 0;       // dont blow out the buffer
   USI_BufIdx++;                                   // inc for next byte in buffer
   USI_Buf[USI_BufIdx] = data;
   return 1;


### PR DESCRIPTION
I was struggling to write multiple init commands from an ATTiny85 to an SSD1306 without ending transmission and beginning transmission again (and telling the SSD1306 to expect commands, again).

Whenever I tried sending all the init commands, in one transmission, the display would remain off.

I had found a Digistump's DigisparkOLED, which uses "Wire" a modified TinyWireM, adding and using a writeAvailable method, but using it in the wrong way, ending and starting a transmission when the buffer was not full, instead of when the buffer was full. Correcting that usage didn't help with my problematic symptoms.

Multiple commands within one transmission were working when setting memory locations to write to, in DigisparkOLED's setCursor function, so I presumed it was a buffer problem, and discovered issue #4 from @moononournation

Applying the fix solved the problem for me, so this is a pull request to apply the identified fix.