### PR TITLE
Bugfix with endTransmission() - return value instead of nothing

### DIFF
--- a/TinyWireM.cpp
+++ b/TinyWireM.cpp
@@ -57,7 +57,7 @@ size_t USI_TWI::write(uint8_t data){ // buffers up data to send
 }
 
 uint8_t USI_TWI::endTransmission() {
-  endTransmission(1);
+  return endTransmission(1);
 }
 
 uint8_t USI_TWI::endTransmission(uint8_t stop){ // actually sends the buffer


### PR DESCRIPTION
Simple bugfix to let people be able to use `endTransmission()` function without parameters to e.g. scan `i2c` bus.