### PR TITLE
Added end()  function to release USI

### DIFF
--- a/TinyWireM.cpp
+++ b/TinyWireM.cpp
@@ -125,9 +125,7 @@ int USI_TWI::available() { // the bytes available that haven't been read yet
   return USI_BytesAvail - (USI_LastRead);
 }
 
-void USI_TWI::end() {
-  USI_TWI_Master_Stop();
-}
+void USI_TWI::end() { USI_TWI_Master_Stop(); }
 
 // Preinstantiate Objects //////////////////////////////////////////////////////
 

--- a/TinyWireM.cpp
+++ b/TinyWireM.cpp
@@ -125,6 +125,10 @@ int USI_TWI::available() { // the bytes available that haven't been read yet
   return USI_BytesAvail - (USI_LastRead);
 }
 
+void USI_TWI::end() {
+  USI_TWI_Master_Stop();
+}
+
 // Preinstantiate Objects //////////////////////////////////////////////////////
 
 /*!

--- a/TinyWireM.h
+++ b/TinyWireM.h
@@ -182,6 +182,11 @@ public:
       return 0;
     return c;
   }
+  /*!
+   * @brief Function for generating a TWI Stop Condition. Used to release
+   * the TWI bus
+   */
+  void end();
 };
 
 extern USI_TWI TinyWireM;

--- a/keywords.txt
+++ b/keywords.txt
@@ -16,6 +16,7 @@ endTransmission	KEYWORD2
 requestFrom	KEYWORD2
 write	KEYWORD2
 read	KEYWORD2
+end KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
This pull requests adds an `end()` function to the library, compatible with the Arduino Wire library. The functions calls `USI_TWI_Master_Stop()` which releases the USI bus, enabling the bus to be used for other purposes.